### PR TITLE
respd: SCAN implementation

### DIFF
--- a/metastore/src/meta_store.rs
+++ b/metastore/src/meta_store.rs
@@ -179,7 +179,7 @@ impl MetaStore {
     pub fn list_buckets(&self) -> Result<Vec<BucketMeta>, MetaError> {
         let bucketlist_tree = self.get_bucketlist_tree()?;
         let buckets = bucketlist_tree
-            .iter_all()
+            .iter_kv(None)
             .filter_map(|result| {
                 let (_, value) = match result {
                     Ok(kv) => kv,

--- a/metastore/src/stores/fjall.rs
+++ b/metastore/src/stores/fjall.rs
@@ -243,10 +243,10 @@ impl BaseMetaTree for FjallTree {
 }
 
 impl MetaTreeExt for FjallTree {
-    fn iter_all(&self) -> KeyValuePairs {
+    fn iter_kv(&self, start_after: Option<Vec<u8>>) -> KeyValuePairs {
         let partition = self.partition.clone();
         let keyspace = self.keyspace.clone();
-        let mut last_key: Option<Vec<u8>> = None;
+        let mut last_key = start_after;
 
         Box::new(std::iter::from_fn(move || {
             let read_tx = keyspace.read_tx();

--- a/metastore/src/stores/test_utils.rs
+++ b/metastore/src/stores/test_utils.rs
@@ -27,7 +27,7 @@ pub fn test_get_bucket_keys(store: &impl TestStore) {
     let bucket = store.get_bucket_ext(bucket_name).unwrap();
 
     let retrieved_keys: Vec<String> = bucket
-        .iter_all()
+        .iter_kv(None)
         .into_iter()
         .map(|kv| String::from_utf8(kv.unwrap().0).unwrap())
         .collect();
@@ -42,7 +42,7 @@ pub fn test_get_bucket_keys(store: &impl TestStore) {
     let empty_bucket = "empty-bucket";
     let _ = store.tree_open(empty_bucket);
     let empty = store.get_bucket_ext(empty_bucket).unwrap();
-    assert_eq!(empty.iter_all().count(), 0);
+    assert_eq!(empty.iter_kv(None).count(), 0);
 }
 
 pub fn test_range_filter(store: &impl TestStore) {

--- a/metastore/src/traits.rs
+++ b/metastore/src/traits.rs
@@ -65,9 +65,12 @@ pub type KeyValuePairs = Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>), Meta
 pub trait MetaTreeExt: BaseMetaTree {
     /// Iterates over all key-value pairs in the tree.
     ///
+    /// # Arguments
+    /// * `start_after` - Optional key to start iteration after (exclusive)
+    ///
     /// # Returns
     /// * `KeyValuePairs` - A boxed iterator over all key-value pairs
-    fn iter_all(&self) -> KeyValuePairs;
+    fn iter_kv(&self, start_after: Option<Vec<u8>>) -> KeyValuePairs;
 
     /// Filters and iterates over a range of keys with optional filtering parameters.
     ///

--- a/respd/README.md
+++ b/respd/README.md
@@ -35,6 +35,7 @@ By default, respd listens on `127.0.0.1:6379` and can be accessed using any Redi
 | NSINFO <n>     | Show info about a namespace              | `NSINFO mynamespace`               |
 | NSLIST           | List all available namespaces            | `NSLIST`                           |
 | DBSIZE           | Get the number of keys in the current namespace (approximate) | `DBSIZE`                          |
+| SCAN [cursor]     | Incrementally iterate over keys in the current namespace | `SCAN 0` or `SCAN mycursor`        |
 
 - All commands are case-insensitive.
 - Namespace commands (`SELECT`, `NSNEW`, `NSINFO`, `NSLIST`) allow multi-tenant data separation.

--- a/respd/src/cmd.rs
+++ b/respd/src/cmd.rs
@@ -616,8 +616,7 @@ impl CommandHandler {
                     let next_cursor = String::from_utf8_lossy(last_key).to_string();
 
                     // Convert keys to frames
-                    let key_frames: Vec<Frame> =
-                        keys.into_iter().map(|k| Frame::BulkString(k)).collect();
+                    let key_frames: Vec<Frame> = keys.into_iter().map(Frame::BulkString).collect();
 
                     // Return [cursor, [keys...]]
                     let response = vec![

--- a/respd/src/namespace.rs
+++ b/respd/src/namespace.rs
@@ -114,7 +114,11 @@ impl Namespace {
         self.tree.len()
     }
 
-    pub fn scan(&self, start_after: Option<Vec<u8>>) -> Result<Vec<Vec<u8>>, MetaError> {
+    pub fn scan(
+        &self,
+        start_after: Option<Vec<u8>>,
+        num_keys: u32,
+    ) -> Result<Vec<Vec<u8>>, MetaError> {
         let mut keys = Vec::new();
         let mut count = 0;
 
@@ -123,7 +127,7 @@ impl Namespace {
                 Ok((key, _)) => {
                     keys.push(key);
                     count += 1;
-                    if count >= 10 {
+                    if count >= num_keys {
                         break;
                     }
                 }

--- a/respd/src/storage.rs
+++ b/respd/src/storage.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use metastore::{BaseMetaTree, Durability, FjallStore, MetaError, MetaStore};
+use metastore::{Durability, FjallStore, MetaError, MetaStore, MetaTreeExt};
 
 // Default tree name for key-value storage
 // No longer using a default tree name as we'll use the namespace as the tree name
@@ -43,7 +43,10 @@ impl Storage {
     }
 
     /// Get a namespace instance for a specific namespace name
-    pub fn get_namespace(&self, name: &str) -> Result<Box<dyn BaseMetaTree>, StorageError> {
+    pub fn get_namespace(
+        &self,
+        name: &str,
+    ) -> Result<Box<dyn MetaTreeExt + Send + Sync>, StorageError> {
         if !self.store.bucket_exists(name)? {
             return Err(StorageError::NamespaceNotFound);
         }
@@ -51,7 +54,7 @@ impl Storage {
         // TODO: get namespace meta
 
         self.store
-            .get_tree(name)
+            .get_bucket_ext(name)
             .map_err(|e| StorageError::MetaError(e.to_string()))
     }
 
@@ -70,7 +73,10 @@ impl Storage {
         }
     }
 
-    pub fn create_namespace(&self, name: &str) -> Result<Box<dyn BaseMetaTree>, StorageError> {
+    pub fn create_namespace(
+        &self,
+        name: &str,
+    ) -> Result<Box<dyn MetaTreeExt + Send + Sync>, StorageError> {
         if self.store.bucket_exists(name)? {
             return Err(StorageError::NamespaceNotFound);
         }

--- a/respd/src/storage.rs
+++ b/respd/src/storage.rs
@@ -90,8 +90,8 @@ impl Storage {
         // Get the all buckets tree which contains namespace metadata
         let bucketlist_tree = self.store.get_bucketlist_tree()?;
 
-        // Use tree.iter_all to iterate over all key-value pairs in the tree
-        let kv_pairs = bucketlist_tree.iter_all();
+        // Use tree.iter_kv to iterate over all key-value pairs in the tree
+        let kv_pairs = bucketlist_tree.iter_kv(None);
 
         // Transform the iterator to yield NamespaceMeta structs
         let namespace_iter = kv_pairs.map(|kv_result| {

--- a/s3cas/src/cas/fs.rs
+++ b/s3cas/src/cas/fs.rs
@@ -255,7 +255,7 @@ impl CasFS {
 
         // removes all objects in the bucket
         let bucket = self.meta_store.get_bucket_ext(bucket_name)?;
-        for key_val in bucket.iter_all() {
+        for key_val in bucket.iter_kv(None) {
             let (key, _) = key_val?;
             self.delete_object(
                 bucket_name,


### PR DESCRIPTION
refactor `iter_all`: add argument and rename
- add `start_after` argument to make the fn more configurable
- rename to `iter_kv` to be more descriptive

Implement `SCAN` command