### PR TITLE
change namespace as singleton & `worm` implementation

### DIFF
--- a/respd/src/cmd.rs
+++ b/respd/src/cmd.rs
@@ -342,7 +342,7 @@ pub struct CommandHandler {
     storage: Arc<Storage>,
 
     // Namespace for this connection
-    namespace: Namespace,
+    namespace: Arc<Namespace>,
 
     // Flag indicating if this connection has admin privileges
     is_admin: bool,
@@ -350,7 +350,7 @@ pub struct CommandHandler {
 
 impl CommandHandler {
     /// Create a new command handler
-    pub fn new(storage: Arc<Storage>, namespace: Namespace, is_admin: bool) -> Self {
+    pub fn new(storage: Arc<Storage>, namespace: Arc<Namespace>, is_admin: bool) -> Self {
         Self {
             storage,
             namespace,

--- a/respd/src/namespace.rs
+++ b/respd/src/namespace.rs
@@ -230,7 +230,7 @@ impl Namespace {
         if worm_enabled {
             // In WORM mode, check if key already exists
             if self.exists(key)? {
-                return Err(anyhow::anyhow!("Namespace is protected by worm mode"));
+                return Err(anyhow::anyhow!("ERR: Namespace is protected by worm mode"));
             }
         }
 
@@ -274,7 +274,7 @@ impl Namespace {
         let worm_enabled = self.properties.read().unwrap().worm;
         if worm_enabled {
             return Err(anyhow::anyhow!(
-                "Cannot delete a key when namespace is in worm mode"
+                "ERR: Cannot delete a key when namespace is in worm mode"
             ));
         }
 

--- a/respd/tests/integration_test.rs
+++ b/respd/tests/integration_test.rs
@@ -768,8 +768,8 @@ mod test_config {
         );
         if let Err(err) = modify_result {
             assert!(
-                err.to_string().contains("worm mode"),
-                "Error should mention WORM mode"
+                err.to_string().contains("ERR:") && err.to_string().contains("worm mode"),
+                "Error should mention ERR: prefix and WORM mode"
             );
         }
 
@@ -779,8 +779,8 @@ mod test_config {
         assert!(del_result.is_err(), "Deleting key in WORM mode should fail");
         if let Err(err) = del_result {
             assert!(
-                err.to_string().contains("worm mode"),
-                "Error should mention WORM mode"
+                err.to_string().contains("ERR:") && err.to_string().contains("worm mode"),
+                "Error should mention ERR: prefix and WORM mode"
             );
         }
 

--- a/respd/tests/integration_test.rs
+++ b/respd/tests/integration_test.rs
@@ -47,22 +47,22 @@ impl TestServer {
                 let addr = format!("127.0.0.1:{}", thread_port);
                 let listener = TcpListener::bind(&addr).expect("Failed to bind to address");
                 println!("Listening on: {}", addr);
-                
+
                 // Create a shared storage instance
                 let storage = Arc::new(respd::storage::Storage::new(thread_data_dir, None));
-                
+
                 // Create a shared namespace cache
                 let namespace_cache = Arc::new(respd::namespace::NamespaceCache::new(storage.clone()));
-                
+
                 // Convert to tokio TcpListener
                 let listener = tokio::net::TcpListener::from_std(listener).expect("Failed to convert listener");
-                
+
                 // Create a future that completes when shutdown signal is received
                 let shutdown_future = async {
                     let _ = shutdown_receiver.await;
                     println!("Shutdown signal received");
                 };
-                
+
                 // Accept connections until shutdown signal is received
                 tokio::select! {
                     _ = shutdown_future => {
@@ -73,16 +73,16 @@ impl TestServer {
                             match listener.accept().await {
                                 Ok((socket, addr)) => {
                                     println!("Accepted connection from: {}", addr);
-                                    
+
                                     // Clone the storage for this connection
                                     let storage = Arc::clone(&storage);
-                                    
+
                                     // Clone the namespace cache for this connection
                                     let namespace_cache = Arc::clone(&namespace_cache);
-                                    
+
                                     // Spawn a new task to handle this connection
                                     // Clone admin password for this connection
-                                    let admin_password = thread_admin_password.clone();     
+                                    let admin_password = thread_admin_password.clone();
                                     tokio::spawn(async move {
                                         // Pass admin_password to the process function
                                         if let Err(e) = respd::server::process(socket, storage, namespace_cache, admin_password).await {


### PR DESCRIPTION
Change to singleton because namespace property can be changed during runtime